### PR TITLE
Update CI GH Action to auto-publish to PyPI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,13 @@
 name: "CI" # Note that this name appears in the README's badge
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  release:
+    types: [published]
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -24,3 +30,24 @@ jobs:
         run: pip install tox
       - name: Run tox
         run: tox -e py${{ matrix.python-version }}-${{ matrix.django-tox-env }}
+
+  release:
+    name: django-jinja-markdown Release
+    if: github.event_name == 'release' && github.event.action == 'published'
+    needs:
+      - test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - name: Install dependencies for package building only
+        run: pip install build
+      - name: Build package for upload to PyPI
+        run: python -m build .
+      - name: Upload the distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@v1.5.0
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/README.rst
+++ b/README.rst
@@ -82,3 +82,14 @@ History
 Forked in 2016 from the
 `jingo-markdown <https://github.com/nrsimha/jingo-markdown>`__ project.
 Please see CHANGELOG for more history.
+
+
+Releasing
+---------
+
+1. Update the version number in ``django_jinja_markdown/__about__.py``.
+2. Add an entry to the change log in the README file.
+3. Tag the commit where you changed the above with the version number: e.g. ``1.21``.
+4. Push the commit and tag to the github repo.
+5. Create a new GitHub release, selecting the tag you just pushed to specify the commit. Hit Publish.
+6. Github will build and release the package to PyPI. Monitor the progress via the Actions tab.


### PR DESCRIPTION
Add GH Action workflow to auto-upload to PyPI when a release is made.

DONE ~Note that this will not work until a PyPI token has been set as an environment secret for the Action, with the name `PYPI_API_TOKEN`~